### PR TITLE
Update table for zoning-map-amendments and add status column

### DIFF
--- a/search-helpers/zoning-map-amendment.js
+++ b/search-helpers/zoning-map-amendment.js
@@ -8,8 +8,9 @@ const zoningMapAmendment = (string) => {
   const SQL = `
     SELECT
       project_na,
+      status,
       ulurpno
-    FROM zoning_map_amendments_v201710
+    FROM zoning_map_amendments_v20181206
     WHERE
       LOWER(project_na) LIKE LOWER('%25${string.toUpperCase()}%25') OR LOWER(ulurpno) LIKE LOWER('%25${string}%25')
     LIMIT 5


### PR DESCRIPTION
Users should be able to search zoning map amendments by project name and ulurp number. PENDING zoning map amendments and adopted zoning map amendments are on the same Carto table, where the status for pending is `certified` and the status for adopted is `adopted`. Going to put these in the same search-helper but put `pending` or `adopted` in the search helper so users know the status of the amendment.
