### PR TITLE
764: use aliased views for new jan data

### DIFF
--- a/search-helpers/commercial-overlay.js
+++ b/search-helpers/commercial-overlay.js
@@ -1,16 +1,21 @@
-// const carto = require('../utils/carto');
-
-const overlays = ['C1-1', 'C1-2', 'C1-3', 'C1-4', 'C1-5', 'C2-1', 'C2-2', 'C2-3', 'C2-4', 'C2-5'];
+const carto = require('../utils/carto');
 
 const commercialOverlay = (string) => {
-  return new Promise((resolve) => {
-    const matches = overlays.filter(overlay => overlay.toLowerCase().indexOf(string.toLowerCase()) !== -1);
-    const results = matches.map(result => ({
-      label: result,
-      type: 'commercial-overlay',
+  const SQL = `
+    SELECT DISTINCT overlay
+    FROM commercial_overlays
+    WHERE LOWER(overlay) LIKE LOWER('%25${string.toLowerCase()}%25')
+    ORDER BY overlay ASC
+    LIMIT 5
+  `;
+
+  return carto.SQL(SQL)
+    .then(rows => rows.map((row) => {
+      row.label = row.overlay;
+      row.type = 'commercial-overlay';
+      delete row.overlay;
+      return row;
     }));
-    resolve(results);
-  });
 };
 
 module.exports = commercialOverlay;

--- a/search-helpers/special-purpose-district.js
+++ b/search-helpers/special-purpose-district.js
@@ -3,7 +3,7 @@ const carto = require('../utils/carto');
 const zoningDistrict = (string) => {
   const SQL = `
     SELECT DISTINCT sdname, cartodb_id
-    FROM special_purpose_districts_v20181206
+    FROM special_purpose_districts
     WHERE LOWER(sdname) LIKE LOWER('%25${string.toLowerCase()}%25')
     LIMIT 5
   `;

--- a/search-helpers/zoning-district.js
+++ b/search-helpers/zoning-district.js
@@ -3,7 +3,7 @@ const carto = require('../utils/carto');
 const zoningDistrict = (string) => {
   const SQL = `
     SELECT DISTINCT zonedist
-    FROM zoning_districts_v20181206
+    FROM zoning_districts
     WHERE LOWER(zonedist) LIKE LOWER('%25${string.toLowerCase()}%25')
     ORDER BY zonedist ASC
     LIMIT 5

--- a/search-helpers/zoning-map-amendment.js
+++ b/search-helpers/zoning-map-amendment.js
@@ -10,7 +10,7 @@ const zoningMapAmendment = (string) => {
       project_na,
       status,
       ulurpno
-    FROM zoning_map_amendments_v20181206
+    FROM zoning_map_amendments
     WHERE
       LOWER(project_na) LIKE LOWER('%25${string.toUpperCase()}%25') OR LOWER(ulurpno) LIKE LOWER('%25${string}%25')
     LIMIT 5


### PR DESCRIPTION
Updates some Carto queries to use new aliased views that have been created on Carto for datasets that have new Jan versions.

Closes #27 and closes NYCPlanning/labs-zola#764. More info about the views is available in the layers-api PR description: NYCPlanning/labs-layers-api#106