### PR TITLE
30 referer prefix

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -92,5 +92,5 @@ function onListening() {
     ? `pipe ${addr}`
     : `port ${addr.port}`;
   debug(`Listening on ${bind}`);
-  console.log(`ZoLa Search API running on port ${bind}`)
+  console.log(`NYC Planning Labs Search API running on port ${bind}`)
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "underscore.string": "3.3.5"
   },
   "engines": {
-    "node": "^10.6.0"
+    "node": "^8.11.3"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "capital-planning-api",
+  "name": "labs-search-api",
   "version": "0.0.1",
   "scripts": {
     "start": "node ./bin/www",
@@ -28,8 +28,7 @@
     "underscore.string": "3.3.5"
   },
   "engines": {
-    "node": "8.11.3",
-    "npm": "5.3.0"
+    "node": "^10.6.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.1",

--- a/routes/search.js
+++ b/routes/search.js
@@ -46,7 +46,7 @@ router.get('/:search_helper', (req, res) => {
     const { q } = req.query;
     const cleanedString = q.replace('\'', '\'\'');
 
-    search_helper(cleanedString).then((data) => {
+    search_helper(cleanedString, req).then((data) => {
       res.json(data);
     });
   }

--- a/routes/search.js
+++ b/routes/search.js
@@ -19,7 +19,7 @@ router.get('/', (req, res) => {
     const camelizedHelperName = camelize(helper);
     const search_helper = searchHelpers[camelizedHelperName];
 
-    return search_helper(cleanedString);
+    return search_helper(cleanedString, req);
   });
 
 

--- a/search-helpers/geosearch.js
+++ b/search-helpers/geosearch.js
@@ -1,10 +1,15 @@
 const rp = require('request-promise');
 
-const geosearch = (string) => {
+const geosearch = (string, req) => {
+  const referer = req.header('Referer');
   const geoSearchAPICall =
    `https://geosearch.planninglabs.nyc/v1/autocomplete?boundary.rect.min_lon=-74.292297&boundary.rect.max_lon=-73.618011&boundary.rect.min_lat=40.477248&boundary.rect.max_lat=40.958123&text=${string}`;
 
-  return rp(geoSearchAPICall)
+  return rp(geoSearchAPICall, {
+    headers: {
+      'Referer': `labs-search-api--${referer}`, // eslint-disable-line
+    },
+  })
     .then(res => JSON.parse(res))
     .then(json => json.features.filter(feature => feature.properties.borough))
     .then(json => json.map((feature) => {


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR appends `labs-layers-api--` to the referer of requests that use the geosearch helper, for better logging on geosearch.

Closes #30