### PR TITLE
use carto view for mappluto

### DIFF
--- a/search-helpers/bbl.js
+++ b/search-helpers/bbl.js
@@ -15,7 +15,7 @@ const bbl = async (string) => {
         WHEN borough = 'BK' THEN 'Brooklyn'
         WHEN borough = 'QN' THEN 'Queens'
         WHEN borough = 'SI' THEN 'Staten Island'
-      END) as address, bbl FROM mappluto_18v2
+      END) as address, bbl FROM mappluto
      WHERE bbl = ${string}
      LIMIT 5
   `;


### PR DESCRIPTION
This PR keeps `mappluto` bbl search results up to date by using the Carto `mappluto` view which points to the latest version. A user had noticed that for some of the latest BBLs created by new construction there were no results. 